### PR TITLE
Link errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS := $(shell pkg-config --libs libusb-1.0)
 all: $(EXE)
 
 $(EXE): $(EXE).c
-	gcc $(CFLAGS) $(LDFLAGS) -o $@ $^
+	gcc $^ $(CFLAGS) $(LDFLAGS) -o $@
 
 clean:
 	rm -f *.o $(EXE)


### PR DESCRIPTION
I was getting link errors...nothing referenced symbols in the libusb library at the time it was linked in, so it was ignored. The fix is simply to rearrange the order of the libraries and source code on the GCC command line.
