### PR TITLE
Fixed return code, updated Makefile

### DIFF
--- a/lm4flash/Makefile
+++ b/lm4flash/Makefile
@@ -3,7 +3,7 @@ EXE := lm4flash
 CFLAGS := -Wall $(shell pkg-config --cflags libusb-1.0)
 LDFLAGS := $(shell pkg-config --libs libusb-1.0)
 
-all: CLFAGS += -O2
+all: CFLAGS += -O2
 all: $(EXE)
 
 debug: CFLAGS += -g -DDEBUG

--- a/lm4flash/lm4flash.c
+++ b/lm4flash/lm4flash.c
@@ -730,7 +730,7 @@ static int flasher_flash(const char *serial, const char *rom_name)
 		goto done;
 	}
 
-	switch (flasher_find_matching_device(
+	switch (retval = flasher_find_matching_device(
 	        ctx, &device, &retval, ICDI_VID, ICDI_PID, serial)) {
 	case FLASHER_SUCCESS:
 		break;


### PR DESCRIPTION
-When using LM4Flash would return 0 in some cases of failure (like Unable to find any ICDI devices), this is now fixed.
-Updated the makefile of LM4Flash to be able to make a debugbuild.
