### PR TITLE
Added OS X support to the Makefile

### DIFF
--- a/lm4flash/Makefile
+++ b/lm4flash/Makefile
@@ -1,9 +1,16 @@
 EXE := lm4flash
 
-CC ?= gcc
+os := ${shell uname -s}
 
+ifeq (${os},Darwin)
+CC := clang
+CFLAGS := -Wall -I/usr/local/include/libusb-1.0
+LDFLAGS := -L/usr/local/lib -lusb-1.0
+else
+CC ?= gcc
 CFLAGS := -Wall $(shell pkg-config --cflags libusb-1.0)
 LDFLAGS := $(shell pkg-config --libs libusb-1.0)
+endif
 
 all: CFLAGS += -O2
 all: $(EXE)


### PR DESCRIPTION
Changed `CFLAGS` and `LDFLAGS` to find libusb-1.0 as installed by Homebrew. The existing Linux flags are used if OS != Darwin. With these changes it compiles with a simple `make` command and I was able to upload a .bin file to my TM4C129x LaunchPad.